### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/topics/cryptography/README.md
+++ b/topics/cryptography/README.md
@@ -19,13 +19,13 @@
 * Any hints about keys? signing? most likely [RSA](./rsa/)
 
 
-##About
+## About
 
 > Cryptography is the practice and study of techniques for secure communication in the presence of third parties. - [Wikipedia](http://en.wikipedia.org/wiki/Cryptography)
 
 In the case of CTFs, the goal is usually to crack or clone cryptographic objects or algorithms to reach the flag.
 
-###Example
+### Example
 
 If you look around the folders in this page you should be able to find a suitable way to solve this simple cipher:
 
@@ -35,6 +35,6 @@ Hint: Julius Caesar's favorite cipher
 kxn iye lbedec
 ```
 
-##Sources/See More
+## Sources/See More
 
 [Introduction to Cryptography](http://www.cs.umd.edu/~waa/414-F11/IntroToCrypto.pdf)

--- a/topics/cryptography/base64/README.md
+++ b/topics/cryptography/base64/README.md
@@ -1,8 +1,8 @@
-#Base64 Encoding
+# Base64 Encoding
 
 Base64 encoding is a way to represent binary data as text.
 
-##Use
+## Use
 
 * Encode:
 
@@ -14,7 +14,7 @@ Base64 encoding is a way to represent binary data as text.
 
     * The [base64](http://linux.die.net/man/1/base64) command line program
 
-##More
+## More
 
 [Base64](https://en.wikipedia.org/wiki/Base64)
 

--- a/topics/cryptography/caesar-cipher/README.md
+++ b/topics/cryptography/caesar-cipher/README.md
@@ -1,8 +1,8 @@
-#Caesar Cipher
+# Caesar Cipher
 
 The Caesar Cipher is a very simple and common encryption method which shifts a string of letters a certain number of positions up or down the alphabet.
 
-##Use
+## Use
 
 * Create:
 
@@ -16,6 +16,6 @@ The Caesar Cipher is a very simple and common encryption method which shifts a s
 
     * [Bash script](http://www.linux-support.com/cms/chris-lamb-decrypting-the-caesar-cipher-using-shell/)
 
-##More
+## More
 
 [Caesar Cipher](https://en.wikipedia.org/wiki/Caesar_cipher)

--- a/topics/cryptography/md5/README.md
+++ b/topics/cryptography/md5/README.md
@@ -1,8 +1,8 @@
-#MD5 Hashing
+# MD5 Hashing
 
 MD5 is a hashing function which creates a 16-byte hash value (usually represented as a 32 digit hexadecimal number) from any file.
 
-#Use
+# Use
 
 * Create a hash:
 
@@ -14,6 +14,6 @@ MD5 is a hashing function which creates a 16-byte hash value (usually represente
 
     * Online [here](http://www.md5decrypter.co.uk/)
 
-##More
+## More
 
 [MD5](https://en.wikipedia.org/wiki/Md5)

--- a/topics/cryptography/rsa/README.md
+++ b/topics/cryptography/rsa/README.md
@@ -1,13 +1,13 @@
-#RSA
+# RSA
 
 RSA is a public-key cryptosystem which uses a public-private key pair to encrypt and decrypt information securely.
 
-##Use
+## Use
 
 * RSA library in [python](https://pypi.python.org/pypi/rsa) with easy to use [docs](http://stuvel.eu/files/python-rsa-doc/usage.html)
 
 * [Thorough explanation](http://www.muppetlabs.com/~breadbox/txt/rsa.html) of RSA with a [simple crack example](http://www.muppetlabs.com/~breadbox/txt/rsa.html#13)
 
-##More
+## More
 
 [RSA](https://en.wikipedia.org/wiki/RSA_algorithm)

--- a/topics/cryptography/sha1/README.md
+++ b/topics/cryptography/sha1/README.md
@@ -1,8 +1,8 @@
-#SHA1 Hash
+# SHA1 Hash
 
 SHA1 is a hash function which creates a 20-byte hash value (usually represented by a 40 digit hexadecimal number) from any file.
 
-##Use
+## Use
 
 * Create a hash:
 
@@ -14,6 +14,6 @@ SHA1 is a hash function which creates a 20-byte hash value (usually represented 
 
     * Online [here](http://www.stringfunction.com/sha1-decrypter.html)
 
-##More
+## More
 
 [SHA1](https://en.wikipedia.org/wiki/Sha1)

--- a/topics/cryptography/vigenere-cipher/README.md
+++ b/topics/cryptography/vigenere-cipher/README.md
@@ -1,8 +1,8 @@
-#Vigenère Cipher
+# Vigenère Cipher
 
 The Vigenère Cipher is an encrypting method which uses a series of different Caesar ciphers based on the letters of a keyword
 
-##Use
+## Use
 
 * Create:
 
@@ -12,7 +12,7 @@ The Vigenère Cipher is an encrypting method which uses a series of different Ca
 
 	* Online [here](http://smurfoncrack.com/pygenere/index.php)
 
-##Sources/See More
+## Sources/See More
 
 [Online Vigenère cracker](http://www.mygeocachingprofile.com/codebreaker.vigenerecipher.aspx)
 

--- a/topics/reversing/README.md
+++ b/topics/reversing/README.md
@@ -1,13 +1,13 @@
-#Reversing
+# Reversing
 
-##Quick Start
+## Quick Start
 
 *To-do*
 
-##About
+## About
 
 Reversing in the context of CTFs is usually the reverse engineering of software (executables/bin files) into assembly code and at times the original source code to understand what is happening in a program, break a program (e.g. buffer overflows), or to decrypt encryptions done by a program. Challenges related to reversing are usually not as easy to pick up on as others, and require a lot of diligence and learning to truly understand and be able to tackle.
 
-##Getting Started
+## Getting Started
 
 * [Reverse Engineering for Beginners](https://github.com/dennis714/RE-for-beginners) - an extremely well-written and verbose free book which explains multiple CPU instruction sets and methods for writing and understanding them.

--- a/topics/steganography/README.md
+++ b/topics/steganography/README.md
@@ -1,15 +1,15 @@
-#Steganography
+# Steganography
 
-##Quick Start
+## Quick Start
 
 * If the file is an image, see [File in an Image](./file-in-image/) or [Hidden Text](./invisible-text/)
 
-##About
+## About
 
 Steganography involves concealing a message, image, or file within anotVher message, image, or file.
 
 In the context of CTFs steganography usually involves finding the hints or flags that have been hidden with steganography.  Most commonly a media file will be given as a task with no further instructions, and the participants have to be able to uncover the message that has been encoded in the media.
 
-##More
+## More
 
 [Steganography](http://en.wikipedia.org/wiki/Steganography)

--- a/topics/steganography/file-in-image/README.md
+++ b/topics/steganography/file-in-image/README.md
@@ -1,4 +1,4 @@
-#Hiding a file in an image
+# Hiding a file in an image
 
 One of the most common steganography tricks is to hide a file inside of an image.  The file will open normally as an image but will also hold hidden files inside, commonly zip, text, and even other image files.
 
@@ -6,7 +6,7 @@ The reason this works is because when an image file is read it has starting and 
 
 For example, The terminating byte for a JPEG is FF D9 in hex, so using a hex viewer ([xxd](http://linuxcommand.org/man_pages/xxd1.html) is good for linux, or something like [HxD](http://mh-nexus.de/en/hxd/) for windows) you can find out where the image finishes.  These bytes are sometimes hard to find in a sea of numbers though, so looking at the dump of the hex (the text representing the hex bytes) can also help you find hidden .txt or .zip files.
 
-###Example
+### Example
 
 A very simple implementation of this strategy is used in the [example.jpg](example.jpg) file in this directory. If you save it to your computer and open it up with an image viewer, you should be presented with a simple jpg image.
 
@@ -28,19 +28,19 @@ This takes in the image example.jpg, the 'in file' if, reads one block at a time
 
 This is the long way of solving a simple steganography problem but shows how the strategy works. In the Solving section more concise and efficient methods are described.
 
-##Detecting
+## Detecting
 
 These challenges are usually presented as a simple picture with no other instructions, and it is up to the competitor to run it through a hex editor to find out if it involves steganography.  If you are presented with an image and no instructions, your safest bet is that is has something hidden after the closing tags of the image.
 
-##Solving
+## Solving
 
 Although it is possible and at times practical to solve these tasks using linux tools like `dd`, there are some tools that make it much easier. [`Binwalk`](http://binwalk.org/) is an immensely useful tool which automatically detects and extracts files hidden with steganography tools
 
-##CTF Example
+## CTF Example
 
 Steganography of this type is usually not scored very highly but is decently widespread. BackdoorCTF 2014 created one which is generally straightforward, [ctfexample.jpg](ctfexample.jpg), but involves multiple layers.
 
-##Sources/See More
+## Sources/See More
 
 [XXD](http://linuxcommand.org/man_pages/xxd1.html)
 

--- a/topics/web/README.md
+++ b/topics/web/README.md
@@ -1,6 +1,6 @@
-#Web
+# Web
 
-##Quick Start
+## Quick Start
 
 * Login field/text input a central part of website? Two major possible options:
 
@@ -9,10 +9,10 @@
     * If the input is used in the website, possible [XSS vulnerability](./xss/)
 
 
-##About
+## About
 
 Web challenges in CTF competitions usually involve the use of HTTP (or similar protocols) and technologies involved in information transfer and display over the internet like PHP, CMS's (e.g. Django), SQL, Javascript, and more.  There are many tools used to access and interact with the web tasks, and choosing the right one is a major facet of the challenges. Although web browsers are the most common and well known way of interacting with the internet, tools like `curl` and `nc` allow for extra options and parameters to be passed and utilized.
 
-##More
+## More
 
 [Internet Security](https://en.wikipedia.org/wiki/Internet_security)

--- a/topics/web/http/README.md
+++ b/topics/web/http/README.md
@@ -1,1 +1,1 @@
-#HTTP (Hypertext Transfer Protocol)
+# HTTP (Hypertext Transfer Protocol)

--- a/topics/web/php/README.md
+++ b/topics/web/php/README.md
@@ -1,7 +1,7 @@
-#PHP
+# PHP
 
 PHP is [a server-side scripting language designed for web development](http://en.wikipedia.org/wiki/PHP).
 
-##More
+## More
 
 [PHP](http://en.wikipedia.org/wiki/PHP)

--- a/topics/web/sql-injections/README.md
+++ b/topics/web/sql-injections/README.md
@@ -1,11 +1,11 @@
-#SQL Injections
+# SQL Injections
 
-##Use
+## Use
 
 * Learn:
 
     * Good [introduction and database](https://www.owasp.org/index.php/SQL_injection) of SQL injections
 
-##More
+## More
 
 [SQL Injection](https://en.wikipedia.org/wiki/SQL_injection)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
