### PR TITLE
Fix link to DD on wikipedia

### DIFF
--- a/topics/steganography/file-in-image/README.md
+++ b/topics/steganography/file-in-image/README.md
@@ -46,6 +46,6 @@ Steganography of this type is usually not scored very highly but is decently wid
 
 [HxD](http://mh-nexus.de/en/hxd/)
 
-[DD](http://en.wikipedia.org/wiki/Dd_(Unix)
+[DD](https://en.wikipedia.org/wiki/Dd_%28Unix%29)
 
 [Binwalk](http://binwalk.org/)


### PR DESCRIPTION
Old link did not correctly link to the article due to the `(Unix)` part messing up.